### PR TITLE
Added remote whitelist support

### DIFF
--- a/Guardian2.csproj
+++ b/Guardian2.csproj
@@ -7,6 +7,7 @@
 		<Version>2.1.0</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
+		<UnhollowedDllPath>..\..\unhollowed</UnhollowedDllPath>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -16,31 +17,40 @@
 
 	<ItemGroup>
 	  <Reference Include="com.rlabrecque.steamworks.net">
-	    <HintPath>..\..\unhollowed\com.rlabrecque.steamworks.net.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\com.rlabrecque.steamworks.net.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="Il2Cppmscorlib">
-	    <HintPath>..\..\unhollowed\Il2Cppmscorlib.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\Il2Cppmscorlib.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="ProjectM">
-	    <HintPath>..\..\unhollowed\ProjectM.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\ProjectM.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="ProjectM.ScriptableSystems">
-	    <HintPath>..\..\unhollowed\ProjectM.ScriptableSystems.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\ProjectM.ScriptableSystems.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="ProjectM.Shared">
-	    <HintPath>..\..\unhollowed\ProjectM.Shared.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\ProjectM.Shared.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="RCONServerLib">
-	    <HintPath>..\..\unhollowed\RCONServerLib.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\RCONServerLib.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="Unity.Entities">
-	    <HintPath>..\..\unhollowed\Unity.Entities.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\Unity.Entities.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="UnityEngine">
-	    <HintPath>..\..\unhollowed\UnityEngine.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\UnityEngine.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	  <Reference Include="UnityEngine.CoreModule">
-	    <HintPath>..\..\unhollowed\UnityEngine.CoreModule.dll</HintPath>
+	    <HintPath>$(UnhollowedDllPath)\UnityEngine.CoreModule.dll</HintPath>
+	    <Private>False</Private>
 	  </Reference>
 	</ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Guardian is here for you, a simple whitelist system to let you the choice of who
 - Add the player ``SteamID`` into it
 - Save
 
+### Usage of remote lists
+This allows for the mod to load remote whitelist files or data from apis.
+The data returned need to be newline separated `steamID64` ids.
+
+An example of a site that can be used is [whitelist.gorymoon.se](https://whitelist.gorymoon.se/) (twitch subscriber whitelist).
+
+Example on how to setup the config for this:
+```xml
+<RemoteWhitelist>
+    <string>https://example.com/link/to/file.txt</string>
+    <string>https://example.com/link/to/api/endpoint</string>
+</RemoteWhitelist>
+```
+
 ### Usage RCON
 - `guardian (add/remove) (steamId)`
 

--- a/src/Helpers/PluginConfiguration.cs
+++ b/src/Helpers/PluginConfiguration.cs
@@ -35,6 +35,24 @@ public struct PluginConfigurationData
 
     public bool KickPlayer { get; set; } = true;
 
+    [XmlAnyElement("RemoteRefreshIntervalComment")]
+    public XmlComment RemoteRefreshIntervalComment
+    {
+        get => new XmlDocument().CreateComment("How often the whitelist should be refreshed in seconds, will default to 5 seconds if set lower then that.");
+        set { }
+    }
+    
+    public int RemoteRefreshInterval { get; set; } = 300;
+    
+    [XmlAnyElement("RemoteWhitelistComment")]
+    public XmlComment RemoteWhitelistComment
+    {
+        get => new XmlDocument().CreateComment("A list of links to remote whitelists containing STEAMID64 ids separated with a newline.");
+        set { }
+    }
+    
+    public string[] RemoteWhitelist { get; set; } = {""};
+    
     public PluginConfigurationData()
     {
     }
@@ -84,6 +102,11 @@ public static class PluginConfiguration
         using var reader = new FileStream(Path.Combine(Plugin.PluginPath, Plugin.PluginConfigurationFileName),
             FileMode.Open);
         Data = (PluginConfigurationData) serializer.Deserialize(reader);
+        reader.Close();
+        
+        // Write again for new configs
+        using var writer = new StreamWriter(Path.Combine(Plugin.PluginPath, Plugin.PluginConfigurationFileName));
+        serializer.Serialize(writer, Data);
     }
 
     /// <summary>

--- a/src/Helpers/RemoteWhitelist.cs
+++ b/src/Helpers/RemoteWhitelist.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+
+namespace Guardian2.Helpers;
+
+public static class RemoteWhitelist
+{
+    public static List<ulong> Whitelisted { get; private set; }
+    
+    /// <summary>
+    /// Update the whitelist based on the remote links 
+    /// </summary>
+    public static (List<ulong> newWhitelist, List<ulong> oldWhitelist) Update()
+    {
+        // Keep the old Whitelisted list if we already have an list.
+        var whitelisted = Whitelisted is {Count: > 0} ? Whitelisted : null;
+
+        // Reinitialize the Whitelisted list each read.
+        Whitelisted = new List<ulong>();
+
+        var lines = new List<string>();
+        var errored = false;
+        
+        foreach (var link in PluginConfiguration.Get().RemoteWhitelist)
+        {
+            var url = link.Trim();
+            if (url.Length > 0)
+            {
+                try
+                {
+                    var request = WebRequest.Create(url);
+                    request.Timeout = 10000;
+                    using var response = request.GetResponse();
+                    using var responseStream = response.GetResponseStream();
+                    if (responseStream != null)
+                    {
+                        using var streamReader = new StreamReader(responseStream);
+                        var data = streamReader
+                            .ReadToEnd()
+                            .Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)
+                            .Select(s => s.Trim())
+                            .Where(s => !string.IsNullOrEmpty(s))
+                            .ToList();
+                        
+                        if (data.Any())
+                            lines.AddRange(data);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Logger.LogError($"Something went wring during fetching of remote whitelist: {url}");
+                    Plugin.Logger.LogError(e.Message);
+                    errored = true;
+                }
+            }
+        }
+
+        foreach (var line in lines.Where(line => !string.IsNullOrEmpty(line)))
+        {
+            if (ulong.TryParse(line, out var result))
+            {
+                // If there's a duplicate, we simply skipping it.
+                if (Whitelisted.Contains(result)) continue;
+
+#if DEBUG
+                Plugin.Logger.LogInfo($"Adding [{result}] to the remote whitelist.");
+#endif
+
+                Whitelisted.Add(result);
+            }
+            else
+            {
+#if DEBUG
+                Plugin.Logger.LogWarning($"Unable to parse [{line}] from remote whitelist, is this a SteamID ?");
+#endif
+            }
+        }
+
+        // Don't remove whitelisted people if there was an error with fetching new ones
+        if (whitelisted != null && errored)
+            Whitelisted.AddRange(whitelisted.Where(o => !Whitelisted.Contains(o)));
+        
+        whitelisted?.RemoveAll(o => Whitelisted.Contains(o));
+
+        return (Whitelisted, whitelisted);
+    }
+    
+}


### PR DESCRIPTION
Hi,

I was looking into creating a whitelist mod myself to support dynamic remote whitelist, after finding this I though it would be better make a PR for it.

I've added new config options for refresh intervals and list of URLs to fetch from. I've also made sure that old config files get updated with new options.

To set it up I tweaked the project file to easier point it to the correct unhollowed file on my system.

This also changes the patches to be more specified to easier see the parameters and the method being patched.


This is an example of the output from a remote endpoint from my service: https://whitelist.gorymoon.se/api/L1KONvmjgpGA62EAzQ98Z/steam_nl